### PR TITLE
update to 11.0.2

### DIFF
--- a/parent/openjfx.base/pom.xml
+++ b/parent/openjfx.base/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>at.bestsolution.openjfx</groupId>
 		<artifactId>parent</artifactId>
-		<version>11.0.0</version>
+		<version>11.0.2</version>
 	</parent>
 	<artifactId>openjfx.base</artifactId>
 

--- a/parent/openjfx.controls/pom.xml
+++ b/parent/openjfx.controls/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>at.bestsolution.openjfx</groupId>
     <artifactId>parent</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.2</version>
   </parent>
   <artifactId>openjfx.controls</artifactId>
   

--- a/parent/openjfx.fxml/pom.xml
+++ b/parent/openjfx.fxml/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>at.bestsolution.openjfx</groupId>
     <artifactId>parent</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.2</version>
   </parent>
   <artifactId>openjfx.fxml</artifactId>
   

--- a/parent/openjfx.graphics.linux_64/pom.xml
+++ b/parent/openjfx.graphics.linux_64/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>at.bestsolution.openjfx</groupId>
     <artifactId>parent</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.2</version>
   </parent>
   <artifactId>openjfx.graphics.linux_64</artifactId>
   

--- a/parent/openjfx.graphics.mac/pom.xml
+++ b/parent/openjfx.graphics.mac/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>at.bestsolution.openjfx</groupId>
     <artifactId>parent</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.2</version>
   </parent>
   <artifactId>openjfx.graphics.mac</artifactId>
   

--- a/parent/openjfx.graphics.win32_64/pom.xml
+++ b/parent/openjfx.graphics.win32_64/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>at.bestsolution.openjfx</groupId>
     <artifactId>parent</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.2</version>
   </parent>
   <artifactId>openjfx.graphics.win32_64</artifactId>
   

--- a/parent/openjfx.media.feature/pom.xml
+++ b/parent/openjfx.media.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>at.bestsolution.openjfx</groupId>
 		<artifactId>parent</artifactId>
-		<version>11.0.0</version>
+		<version>11.0.2</version>
 	</parent>
 	<artifactId>openjfx.media.feature</artifactId>
 

--- a/parent/openjfx.media.linux_64/pom.xml
+++ b/parent/openjfx.media.linux_64/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>at.bestsolution.openjfx</groupId>
     <artifactId>parent</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.2</version>
   </parent>
   <artifactId>openjfx.media.linux_64</artifactId>
   

--- a/parent/openjfx.media.mac/pom.xml
+++ b/parent/openjfx.media.mac/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>at.bestsolution.openjfx</groupId>
     <artifactId>parent</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.2</version>
   </parent>
   <artifactId>openjfx.media.mac</artifactId>
   

--- a/parent/openjfx.media.win32_64/pom.xml
+++ b/parent/openjfx.media.win32_64/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>at.bestsolution.openjfx</groupId>
     <artifactId>parent</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.2</version>
   </parent>
   <artifactId>openjfx.media.win32_64</artifactId>
   

--- a/parent/openjfx.p2/pom.xml
+++ b/parent/openjfx.p2/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>at.bestsolution.openjfx</groupId>
     <artifactId>parent</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.2</version>
   </parent>
   <artifactId>openjfx.p2</artifactId>
   

--- a/parent/openjfx.standard.feature/pom.xml
+++ b/parent/openjfx.standard.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>at.bestsolution.openjfx</groupId>
 		<artifactId>parent</artifactId>
-		<version>11.0.0</version>
+		<version>11.0.2</version>
 	</parent>
 	<artifactId>openjfx.standard.feature</artifactId>
 

--- a/parent/openjfx.swing.feature/pom.xml
+++ b/parent/openjfx.swing.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>at.bestsolution.openjfx</groupId>
 		<artifactId>parent</artifactId>
-		<version>11.0.0</version>
+		<version>11.0.2</version>
 	</parent>
 	<artifactId>openjfx.swing.feature</artifactId>
 

--- a/parent/openjfx.swing/pom.xml
+++ b/parent/openjfx.swing/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>at.bestsolution.openjfx</groupId>
 		<artifactId>parent</artifactId>
-		<version>11.0.0</version>
+		<version>11.0.2</version>
 	</parent>
 	<artifactId>openjfx.swing</artifactId>
 

--- a/parent/openjfx.swt.feature/pom.xml
+++ b/parent/openjfx.swt.feature/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>at.bestsolution.openjfx</groupId>
     <artifactId>parent</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.2</version>
   </parent>
   <artifactId>openjfx.swt.feature</artifactId>
   

--- a/parent/openjfx.swt/pom.xml
+++ b/parent/openjfx.swt/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>at.bestsolution.openjfx</groupId>
 		<artifactId>parent</artifactId>
-		<version>11.0.0</version>
+		<version>11.0.2</version>
 	</parent>
 	<artifactId>openjfx.swt</artifactId>
 

--- a/parent/openjfx.web.feature/pom.xml
+++ b/parent/openjfx.web.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>at.bestsolution.openjfx</groupId>
 		<artifactId>parent</artifactId>
-		<version>11.0.0</version>
+		<version>11.0.2</version>
 	</parent>
 	<artifactId>openjfx.web.feature</artifactId>
 	<dependencies>

--- a/parent/openjfx.web.linux_64/pom.xml
+++ b/parent/openjfx.web.linux_64/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>at.bestsolution.openjfx</groupId>
     <artifactId>parent</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.2</version>
   </parent>
   <artifactId>openjfx.web.linux_64</artifactId>
   

--- a/parent/openjfx.web.mac/pom.xml
+++ b/parent/openjfx.web.mac/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>at.bestsolution.openjfx</groupId>
     <artifactId>parent</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.2</version>
   </parent>
   <artifactId>openjfx.web.mac</artifactId>
   

--- a/parent/openjfx.web.win32_64/pom.xml
+++ b/parent/openjfx.web.win32_64/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>at.bestsolution.openjfx</groupId>
     <artifactId>parent</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.2</version>
   </parent>
   <artifactId>openjfx.web.win32_64</artifactId>
   

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>at.bestsolution.openjfx</groupId>
 	<artifactId>parent</artifactId>
-	<version>11.0.0</version>
+	<version>11.0.2</version>
 	<packaging>pom</packaging>
 	<modules>
 		<module>openjfx.base</module>
@@ -30,7 +30,7 @@
 	</modules>
 	
 	<properties>
-		<openjfx.version>11</openjfx.version>
+		<openjfx.version>11.0.2</openjfx.version>
 		<osgi.qualifier>${maven.build.timestamp}</osgi.qualifier>
 		<maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
 	</properties>


### PR DESCRIPTION
Hi Tom,
currently my eclipse (Spring Tool Suit 4.1.2) has some issues (the import of javafx cannot be resolved) using your openjfx osgi package. Tried to update (see this pull request) but then I get
[ERROR] Plugin at.bestsolution:maven-osgi-package-plugin:0.0.2-SNAPSHOT or one of its dependencies could not be resolved: Could not find artifact at.bestsolution:maven-osgi-package-plugin:jar:0.0.2-SNAPSHOT -> [Help 1]
Is there a sample eclipse product somewhere based on Java 11, Eclipse 4.11, openjfx 11.0.2 with a tycho 1.4.0-SNAPSHOT build?